### PR TITLE
Transform PolyDan into mobile-first phone app

### DIFF
--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to Heroku
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/public/index.html
+++ b/public/index.html
@@ -3,13 +3,16 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#4F46E5" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="PolyDan - Family Iron Man last-man-standing prediction market with fake dollars"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="PolyDan" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
@@ -24,7 +27,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>PolyDan - Iron Man Betting</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "PolyDan",
+  "name": "PolyDan - Iron Man Betting",
   "icons": [
     {
       "src": "favicon.ico",
@@ -18,8 +18,8 @@
       "sizes": "512x512"
     }
   ],
-  "start_url": ".",
+  "start_url": "/",
   "display": "standalone",
-  "theme_color": "#000000",
+  "theme_color": "#4F46E5",
   "background_color": "#ffffff"
 }

--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
@@ -9,6 +9,7 @@ interface AdminLayoutProps {
 const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
   const { user } = useAuth();
   const location = useLocation();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   const isActive = (path: string) => {
     return location.pathname === path;
@@ -25,12 +26,12 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
       {/* Top Navigation Bar */}
       <nav className="bg-white shadow-sm">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between h-16">
-            <div className="flex">
-              <div className="flex-shrink-0 flex items-center">
-                <span className="text-xl font-bold text-indigo-600">Admin Panel</span>
+          <div className="flex justify-between items-center h-16">
+            <div className="flex items-center">
+              <div className="flex-shrink-0">
+                <span className="text-lg sm:text-xl font-bold text-indigo-600">Admin Panel</span>
               </div>
-              <div className="hidden sm:ml-6 sm:flex sm:space-x-8">
+              <div className="hidden md:ml-6 md:flex md:space-x-8">
                 {navItems.map((item) => (
                   <Link
                     key={item.path}
@@ -46,17 +47,51 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
                 ))}
               </div>
             </div>
-            <div className="flex items-center">
-              <span className="text-sm text-gray-500">
-                Logged in as: <span className="font-medium">{user?.email}</span>
+            <div className="flex items-center gap-3">
+              <span className="hidden sm:block text-xs sm:text-sm text-gray-500 truncate max-w-[150px]">
+                {user?.email}
               </span>
+              <button
+                onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+                className="md:hidden inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100"
+              >
+                <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  {mobileMenuOpen ? (
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  ) : (
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                  )}
+                </svg>
+              </button>
             </div>
           </div>
+
+          {/* Mobile menu */}
+          {mobileMenuOpen && (
+            <div className="md:hidden pb-3">
+              <div className="space-y-1">
+                {navItems.map((item) => (
+                  <Link
+                    key={item.path}
+                    to={item.path}
+                    onClick={() => setMobileMenuOpen(false)}
+                    className={`${
+                      isActive(item.path)
+                        ? 'bg-indigo-50 text-indigo-700'
+                        : 'text-gray-700 hover:bg-gray-50'
+                    } block px-4 py-3 min-h-[44px] text-base font-medium rounded-md`}
+                  >
+                    {item.label}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       </nav>
 
       {/* Main Content */}
-      <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+      <main className="max-w-7xl mx-auto py-4 px-4 sm:py-6 sm:px-6 lg:px-8">
         {children}
       </main>
     </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,17 +6,42 @@ export const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) =>
   const { user, signOut } = useAuth();
   const location = useLocation();
   const navigate = useNavigate();
-  const [mobileOpen, setMobileOpen] = useState(false);
+  const [showMoreSheet, setShowMoreSheet] = useState(false);
 
   const handleSignOut = async () => {
     await signOut();
     navigate('/login');
-    setMobileOpen(false);
+    setShowMoreSheet(false);
   };
 
+  // Determine active tab
+  const getActiveTab = () => {
+    if (location.pathname === '/') return 'home';
+    if (location.pathname === '/bets') return 'bets';
+    if (location.pathname === '/leaderboard') return 'leaderboard';
+    return 'more';
+  };
+
+  const activeTab = getActiveTab();
+
   return (
-    <div className="min-h-screen bg-gray-100">
-      <nav className="bg-white shadow-sm" role="navigation" aria-label="Primary">
+    <div className="min-h-screen bg-gray-100 flex flex-col">
+      {/* Compact mobile top bar */}
+      <nav className="md:hidden bg-white shadow-sm sticky top-0 z-10">
+        <div className="flex items-center justify-between px-4 h-14">
+          <Link to="/" className="text-xl font-bold text-indigo-600">
+            PolyDan
+          </Link>
+          {user && (
+            <div className="text-sm font-semibold text-gray-700">
+              ${user.points}
+            </div>
+          )}
+        </div>
+      </nav>
+
+      {/* Desktop top navigation (original design) */}
+      <nav className="hidden md:block bg-white shadow-sm" role="navigation" aria-label="Primary">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between h-16 items-center">
             <div className="flex items-center">
@@ -24,7 +49,7 @@ export const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) =>
                 PolyDan
               </Link>
               {/* Desktop links */}
-              <div className="hidden sm:ml-6 sm:flex sm:space-x-8">
+              <div className="ml-6 flex space-x-8">
                 {[
                   { to: '/', label: 'Home' },
                   { to: '/leaderboard', label: 'Leaderboard' },
@@ -82,156 +107,217 @@ export const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) =>
                 )}
               </div>
             </div>
-
-            {/* Mobile menu button */}
-            <div className="flex sm:hidden">
-              <button
-                type="button"
-                aria-label="Toggle navigation menu"
-                className="inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
-                onClick={() => setMobileOpen(!mobileOpen)}
-              >
-                <svg className="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                  {mobileOpen ? (
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  ) : (
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-                  )}
-                </svg>
-              </button>
-            </div>
           </div>
         </div>
 
-        {/* Mobile menu panel */}
-        {mobileOpen && (
-          <div className="sm:hidden" aria-label="Mobile">
-            {/* Mobile user info */}
-            {user && (
-              <div className="px-4 py-3 border-b border-gray-200 bg-gray-50">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center">
+        {/* Desktop user bar */}
+        <div className="flex justify-end bg-white shadow-sm pr-6 py-2">
+          {user ? (
+            <div className="flex items-center space-x-4">
+              <span className="text-sm text-gray-700">{user.name} (${user.points})</span>
+              <button
+                onClick={handleSignOut}
+                className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+              >
+                Sign Out
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center space-x-4">
+              <Link to="/login" className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-indigo-600 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">Sign In</Link>
+              <Link to="/register" className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">Sign Up</Link>
+            </div>
+          )}
+        </div>
+      </nav>
+
+      {/* Main content with bottom padding for mobile tab bar */}
+      <main className="flex-1 max-w-7xl w-full mx-auto py-4 px-4 sm:px-6 lg:px-8 pb-20 md:pb-6">
+        {children}
+      </main>
+
+      {/* Mobile bottom tab bar */}
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 z-20" style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}>
+        <div className="flex items-center justify-around">
+          <Link
+            to="/"
+            className={`flex flex-col items-center justify-center flex-1 min-h-[44px] py-2 ${
+              activeTab === 'home' ? 'text-indigo-600' : 'text-gray-500'
+            }`}
+            aria-label="Home"
+          >
+            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+            </svg>
+            <span className="text-xs mt-1 font-medium">Home</span>
+          </Link>
+
+          {user ? (
+            <Link
+              to="/bets"
+              className={`flex flex-col items-center justify-center flex-1 min-h-[44px] py-2 ${
+                activeTab === 'bets' ? 'text-indigo-600' : 'text-gray-500'
+              }`}
+              aria-label="Place Bets"
+            >
+              <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <span className="text-xs mt-1 font-medium">Bets</span>
+            </Link>
+          ) : (
+            <Link
+              to="/register"
+              className={`flex flex-col items-center justify-center flex-1 min-h-[44px] py-2 ${
+                activeTab === 'bets' ? 'text-indigo-600' : 'text-gray-500'
+              }`}
+              aria-label="Join"
+            >
+              <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
+              </svg>
+              <span className="text-xs mt-1 font-medium">Join</span>
+            </Link>
+          )}
+
+          <Link
+            to="/leaderboard"
+            className={`flex flex-col items-center justify-center flex-1 min-h-[44px] py-2 ${
+              activeTab === 'leaderboard' ? 'text-indigo-600' : 'text-gray-500'
+            }`}
+            aria-label="Leaderboard"
+          >
+            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+            </svg>
+            <span className="text-xs mt-1 font-medium">Leaders</span>
+          </Link>
+
+          <button
+            onClick={() => setShowMoreSheet(!showMoreSheet)}
+            className={`flex flex-col items-center justify-center flex-1 min-h-[44px] py-2 ${
+              activeTab === 'more' || showMoreSheet ? 'text-indigo-600' : 'text-gray-500'
+            }`}
+            aria-label="More options"
+          >
+            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+            <span className="text-xs mt-1 font-medium">More</span>
+          </button>
+        </div>
+      </nav>
+
+      {/* Mobile "More" sheet */}
+      {showMoreSheet && (
+        <>
+          <div 
+            className="md:hidden fixed inset-0 bg-black bg-opacity-50 z-30"
+            onClick={() => setShowMoreSheet(false)}
+            aria-hidden="true"
+          />
+          <div className="md:hidden fixed bottom-0 left-0 right-0 bg-white rounded-t-2xl shadow-2xl z-40 animate-slide-up" style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}>
+            <div className="p-4">
+              {/* User info if logged in */}
+              {user && (
+                <div className="mb-4 pb-4 border-b border-gray-200">
+                  <div className="flex items-center gap-3">
                     <div className="flex-shrink-0">
-                      <span className="inline-flex items-center justify-center h-8 w-8 rounded-full bg-indigo-100">
-                        <span className="text-sm font-medium leading-none text-indigo-600">
+                      <span className="inline-flex items-center justify-center h-12 w-12 rounded-full bg-indigo-100">
+                        <span className="text-lg font-medium text-indigo-600">
                           {user.name?.charAt(0).toUpperCase()}
                         </span>
                       </span>
                     </div>
-                    <div className="ml-3">
-                      <p className="text-sm font-medium text-gray-700">{user.name}</p>
-                      <p className="text-xs text-gray-500">{user.points} points</p>
+                    <div className="flex-1">
+                      <p className="font-semibold text-gray-900">{user.name}</p>
+                      <p className="text-sm text-gray-600">${user.points} fake dollars</p>
                     </div>
                   </div>
+                </div>
+              )}
+
+              {/* Menu items */}
+              <div className="space-y-1">
+                {[
+                  { to: '/side-bets', label: 'Side Bets', icon: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z' },
+                  { to: '/rules', label: 'Rules', icon: 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z' },
+                  { to: '/faq', label: 'FAQ', icon: 'M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z' },
+                  { to: '/profile', label: 'Profile', icon: 'M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z' },
+                ].map(({ to, label, icon }) => (
+                  <Link
+                    key={to}
+                    to={to}
+                    onClick={() => setShowMoreSheet(false)}
+                    className="flex items-center gap-3 px-4 py-3 min-h-[44px] rounded-lg hover:bg-gray-50 transition"
+                  >
+                    <svg className="w-6 h-6 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={icon} />
+                    </svg>
+                    <span className="font-medium text-gray-900">{label}</span>
+                  </Link>
+                ))}
+                
+                {user?.role === 'admin' && (
+                  <>
+                    <div className="border-t border-gray-200 my-2" />
+                    <Link
+                      to="/admin"
+                      onClick={() => setShowMoreSheet(false)}
+                      className="flex items-center gap-3 px-4 py-3 min-h-[44px] rounded-lg hover:bg-gray-50 transition"
+                    >
+                      <svg className="w-6 h-6 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                      </svg>
+                      <span className="font-medium text-gray-900">Admin</span>
+                    </Link>
+                    <Link
+                      to="/admin/users"
+                      onClick={() => setShowMoreSheet(false)}
+                      className="flex items-center gap-3 px-4 py-3 min-h-[44px] rounded-lg hover:bg-gray-50 transition"
+                    >
+                      <svg className="w-6 h-6 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
+                      </svg>
+                      <span className="font-medium text-gray-900">User Admin</span>
+                    </Link>
+                  </>
+                )}
+              </div>
+
+              {/* Auth buttons */}
+              <div className="mt-4 pt-4 border-t border-gray-200">
+                {user ? (
                   <button
                     onClick={handleSignOut}
-                    className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                    className="w-full flex justify-center items-center px-4 py-3 min-h-[44px] rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white font-medium transition"
                   >
                     Sign Out
                   </button>
-                </div>
+                ) : (
+                  <div className="space-y-2">
+                    <Link
+                      to="/login"
+                      onClick={() => setShowMoreSheet(false)}
+                      className="block w-full text-center px-4 py-3 min-h-[44px] rounded-lg border border-indigo-600 text-indigo-600 font-medium hover:bg-indigo-50 transition"
+                    >
+                      Sign In
+                    </Link>
+                    <Link
+                      to="/register"
+                      onClick={() => setShowMoreSheet(false)}
+                      className="block w-full text-center px-4 py-3 min-h-[44px] rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white font-medium transition"
+                    >
+                      Sign Up
+                    </Link>
+                  </div>
+                )}
               </div>
-            )}
-
-            {/* Mobile navigation links */}
-            <div className="px-2 pt-2 pb-3 space-y-1">
-              {[
-                { to: '/', label: 'Home' },
-                { to: '/leaderboard', label: 'Leaderboard' },
-                { to: '/side-bets', label: 'Side Bets' },
-                { to: '/rules', label: 'Rules' },
-                { to: '/faq', label: 'FAQ' },
-                ...(user ? [{ to: '/bets', label: 'Bets' }] : []),
-              ].map(({ to, label }) => (
-                <Link
-                  key={to}
-                  to={to}
-                  onClick={() => setMobileOpen(false)}
-                  className={`${
-                    location.pathname === to
-                      ? 'bg-indigo-50 text-indigo-700'
-                      : 'text-gray-700 hover:bg-gray-50'
-                  } block px-3 py-2 rounded-md text-base font-medium`}
-                >
-                  {label}
-                </Link>
-              ))}
-              {user?.role === 'admin' && (
-                <>
-                  <Link
-                    to="/admin"
-                    onClick={() => setMobileOpen(false)}
-                    className={`${
-                      location.pathname === '/admin'
-                        ? 'bg-indigo-50 text-indigo-700'
-                        : 'text-gray-700 hover:bg-gray-50'
-                    } block px-3 py-2 rounded-md text-base font-medium`}
-                  >
-                    Admin
-                  </Link>
-                  <Link
-                    to="/admin/users"
-                    onClick={() => setMobileOpen(false)}
-                    className={`${
-                      location.pathname === '/admin/users'
-                        ? 'bg-indigo-50 text-indigo-700'
-                        : 'text-gray-700 hover:bg-gray-50'
-                    } block px-3 py-2 rounded-md text-base font-medium`}
-                  >
-                    Users
-                  </Link>
-                </>
-              )}
             </div>
-
-            {/* Mobile auth buttons */}
-            {!user && (
-              <div className="px-4 py-3 border-t border-gray-200 bg-gray-50">
-                <div className="flex space-x-3">
-                  <Link
-                    to="/login"
-                    onClick={() => setMobileOpen(false)}
-                    className="flex-1 inline-flex justify-center items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-indigo-600 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-                  >
-                    Sign In
-                  </Link>
-                  <Link
-                    to="/register"
-                    onClick={() => setMobileOpen(false)}
-                    className="flex-1 inline-flex justify-center items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-                  >
-                    Sign Up
-                  </Link>
-                </div>
-              </div>
-            )}
           </div>
-        )}
-      </nav>
-
-      {/* Desktop user bar */}
-      <div className="hidden sm:flex justify-end bg-white shadow-sm pr-6 py-2">
-        {user ? (
-          <div className="flex items-center space-x-4">
-            <span className="text-sm text-gray-700">{user.name} ({user.points} points)</span>
-            <button
-              onClick={handleSignOut}
-              className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-            >
-              Sign Out
-            </button>
-          </div>
-        ) : (
-          <div className="flex items-center space-x-4">
-            <Link to="/login" className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-indigo-600 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">Sign In</Link>
-            <Link to="/register" className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">Sign Up</Link>
-          </div>
-        )}
-      </div>
-
-      <main className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-        {children}
-      </main>
+        </>
+      )}
     </div>
   );
-}; 
+};

--- a/src/components/common/FormInput.tsx
+++ b/src/components/common/FormInput.tsx
@@ -24,7 +24,7 @@ export const FormInput: React.FC<FormInputProps> = ({
     placeholder={placeholder}
     data-testid={dataTestId}
     disabled={disabled}
-    className={`w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+    className={`w-full px-4 py-3 text-base border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
       disabled ? 'opacity-50 cursor-not-allowed' : ''
     }`}
   />

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -281,17 +281,17 @@ const Admin: React.FC = () => {
           </div>
 
           <form onSubmit={addChampion} className="mt-5">
-            <div className="flex rounded-md shadow-sm">
+            <div className="flex flex-col sm:flex-row gap-2 sm:gap-0">
               <input
                 type="text"
                 value={newChampionName}
                 onChange={(e) => setNewChampionName(e.target.value)}
-                className="flex-1 rounded-none rounded-l-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                className="flex-1 px-4 py-3 text-base rounded-lg sm:rounded-none sm:rounded-l-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500"
                 placeholder="Enter champion name"
               />
               <button
                 type="submit"
-                className="inline-flex items-center rounded-none rounded-r-md border border-l-0 border-gray-300 bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                className="inline-flex items-center justify-center px-4 py-3 min-h-[44px] rounded-lg sm:rounded-none sm:rounded-r-md border sm:border-l-0 border-gray-300 bg-indigo-600 text-base font-semibold text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition"
               >
                 Add Champion
               </button>
@@ -299,66 +299,54 @@ const Admin: React.FC = () => {
           </form>
 
           <div className="mt-6">
-            <div className="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
-              <table className="min-w-full divide-y divide-gray-300">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900">
-                      Name
-                    </th>
-                    <th className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                      Status
-                    </th>
-                    <th className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                      Actions
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200 bg-white">
-                  {champions.map((champion) => (
-                    <tr key={champion.id}>
-                      <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900">
-                        {champion.name}
-                      </td>
-                      <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+            <div className="space-y-3">
+              {champions.map((champion) => (
+                <div
+                  key={champion.id}
+                  className="bg-white p-4 rounded-lg shadow border border-gray-200"
+                >
+                  <div className="flex items-start justify-between mb-3">
+                    <div>
+                      <h4 className="text-base font-semibold text-gray-900">{champion.name}</h4>
+                      <div className="mt-2">
                         {champion.isWinner ? (
-                          <span className="inline-flex rounded-full bg-green-100 px-2 text-xs font-semibold leading-5 text-green-800">
+                          <span className="inline-flex rounded-full bg-green-100 px-3 py-1 text-sm font-semibold text-green-800">
                             Winner
                           </span>
                         ) : champion.isEliminated ? (
-                          <span className="inline-flex rounded-full bg-red-100 px-2 text-xs font-semibold leading-5 text-red-800">
+                          <span className="inline-flex rounded-full bg-red-100 px-3 py-1 text-sm font-semibold text-red-800">
                             Eliminated
                           </span>
                         ) : (
-                          <span className="inline-flex rounded-full bg-blue-100 px-2 text-xs font-semibold leading-5 text-blue-800">
+                          <span className="inline-flex rounded-full bg-blue-100 px-3 py-1 text-sm font-semibold text-blue-800">
                             Active
                           </span>
                         )}
-                      </td>
-                      <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                        <button
-                          onClick={() => toggleEliminationStatus(champion)}
-                          disabled={isResolving || winner !== undefined}
-                          className="mr-2 rounded bg-red-600 px-2 py-1 text-xs font-semibold text-white shadow-sm hover:bg-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600 disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                          {champion.isEliminated ? 'Restore' : 'Eliminate'}
-                        </button>
-                        <button
-                          onClick={() => setWinner(champion)}
-                          disabled={champion.isWinner || isResolving || winner !== undefined}
-                          className={`rounded px-2 py-1 text-xs font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
-                            champion.isWinner || winner
-                              ? 'bg-gray-400 cursor-not-allowed'
-                              : 'bg-green-600 hover:bg-green-500 focus-visible:outline-green-600'
-                          }`}
-                        >
-                          {champion.isWinner ? 'Current Winner' : 'Crown Winner'}
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex flex-col sm:flex-row gap-2">
+                    <button
+                      onClick={() => toggleEliminationStatus(champion)}
+                      disabled={isResolving || winner !== undefined}
+                      className="flex-1 px-4 py-2 min-h-[44px] rounded-lg bg-red-600 text-base font-semibold text-white hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-600 disabled:opacity-50 disabled:cursor-not-allowed transition"
+                    >
+                      {champion.isEliminated ? 'Restore' : 'Eliminate'}
+                    </button>
+                    <button
+                      onClick={() => setWinner(champion)}
+                      disabled={champion.isWinner || isResolving || winner !== undefined}
+                      className={`flex-1 px-4 py-2 min-h-[44px] rounded-lg text-base font-semibold text-white focus:outline-none focus:ring-2 transition ${
+                        champion.isWinner || winner
+                          ? 'bg-gray-400 cursor-not-allowed'
+                          : 'bg-green-600 hover:bg-green-500 focus:ring-green-600'
+                      }`}
+                    >
+                      {champion.isWinner ? 'Current Winner' : 'Crown Winner'}
+                    </button>
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/src/pages/Bets.tsx
+++ b/src/pages/Bets.tsx
@@ -179,7 +179,7 @@ const Bets: React.FC = () => {
                 id="champion"
                 value={selectedChampion}
                 onChange={(e) => setSelectedChampion(e.target.value)}
-                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-base py-3"
                 required
               >
                 <option value="">Select a champion</option>
@@ -197,56 +197,56 @@ const Bets: React.FC = () => {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700">
+              <label className="block text-sm font-medium text-gray-700 mb-2">
                 Bet Type
               </label>
-              <div className="mt-2 space-y-2">
-                <label className="flex items-center p-3 border rounded-md cursor-pointer hover:bg-gray-50">
+              <div className="space-y-2">
+                <label className="flex items-center p-4 min-h-[44px] border-2 rounded-lg cursor-pointer hover:bg-gray-50 transition">
                   <input
                     type="radio"
                     checked={isBettingFor}
                     onChange={() => setIsBettingFor(true)}
-                    className="form-radio h-4 w-4 text-indigo-600"
+                    className="form-radio h-5 w-5 text-indigo-600"
                   />
-                  <span className="ml-3">
-                    <span className="font-medium">For</span> - Bet this champion will win
+                  <span className="ml-3 text-base">
+                    <span className="font-semibold">For</span> - Bet this champion will win
                   </span>
                 </label>
-                <label className="flex items-center p-3 border rounded-md cursor-pointer hover:bg-gray-50">
+                <label className="flex items-center p-4 min-h-[44px] border-2 rounded-lg cursor-pointer hover:bg-gray-50 transition">
                   <input
                     type="radio"
                     checked={!isBettingFor}
                     onChange={() => setIsBettingFor(false)}
-                    className="form-radio h-4 w-4 text-indigo-600"
+                    className="form-radio h-5 w-5 text-indigo-600"
                   />
-                  <span className="ml-3">
-                    <span className="font-medium">Against</span> - Bet this champion won't win
+                  <span className="ml-3 text-base">
+                    <span className="font-semibold">Against</span> - Bet this champion won't win
                   </span>
                 </label>
               </div>
             </div>
 
             <div>
-              <label htmlFor="amount" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="amount" className="block text-sm font-medium text-gray-700 mb-2">
                 Bet Amount (Fake $)
               </label>
-              <div className="mt-1 relative rounded-md shadow-sm">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <span className="text-gray-500 sm:text-sm">$</span>
+              <div className="relative rounded-md shadow-sm">
+                <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
+                  <span className="text-gray-500 text-base">$</span>
                 </div>
                 <input
                   type="number"
                   id="amount"
                   value={betAmount || ''}
                   onChange={(e) => setBetAmount(Math.max(0, parseInt(e.target.value) || 0))}
-                  className="block w-full pl-7 pr-12 rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                  className="block w-full pl-9 pr-4 py-3 text-base rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500"
                   placeholder="0"
                   required
                   min="1"
                   max={user?.points || 0}
                 />
               </div>
-              <p className="mt-1 text-xs text-gray-500">
+              <p className="mt-2 text-sm text-gray-600">
                 Available: ${user?.points || 0}
               </p>
             </div>
@@ -276,7 +276,7 @@ const Bets: React.FC = () => {
 
             <button
               type="submit"
-              className="w-full inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-3 px-4 text-base font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full inline-flex justify-center items-center rounded-lg border border-transparent bg-indigo-600 py-3 px-4 min-h-[44px] text-base font-semibold text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition"
               disabled={!selectedChampion || betAmount <= 0 || !user || betAmount > user.points || isSubmitting}
             >
               {isSubmitting ? 'Placing Bet...' : 'Place Bet'}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -50,35 +50,35 @@ const Home: React.FC = () => {
   return (
     <div className="space-y-6">
       {/* Hero Header */}
-      <header className="bg-indigo-600 rounded-lg text-white p-4 sm:p-8 shadow">
-        <h1 className="text-2xl sm:text-3xl font-extrabold">PolyDan Iron Man Betting</h1>
-        <p className="mt-2 text-sm sm:text-base text-indigo-100 max-w-2xl">
+      <header className="bg-indigo-600 rounded-lg text-white p-4 sm:p-6 shadow">
+        <h1 className="text-xl sm:text-3xl font-extrabold">PolyDan Iron Man Betting</h1>
+        <p className="mt-2 text-sm sm:text-base text-indigo-100">
           Family-friendly, last-man-standing prediction market. Bet fake dollars on who wins the Iron Man competition!
         </p>
         {user && (
-          <div className="mt-3 text-lg font-semibold text-white">
+          <div className="mt-3 text-base sm:text-lg font-semibold text-white">
             Your Balance: <span className="text-yellow-300">${user.points}</span> fake dollars
           </div>
         )}
-        <div className="mt-4 flex flex-wrap gap-3">
+        <div className="mt-4 flex flex-col sm:flex-row gap-2 sm:gap-3">
           {user ? (
             <Link
               to="/bets"
-              className="inline-flex items-center px-5 py-2.5 rounded-md bg-yellow-400 hover:bg-yellow-300 text-indigo-900 text-sm font-bold transition"
+              className="inline-flex items-center justify-center px-5 py-3 min-h-[44px] rounded-lg bg-yellow-400 hover:bg-yellow-300 text-indigo-900 text-base font-bold transition"
             >
               Place Your Bet
             </Link>
           ) : (
             <Link
               to="/register"
-              className="inline-flex items-center px-5 py-2.5 rounded-md bg-yellow-400 hover:bg-yellow-300 text-indigo-900 text-sm font-bold transition"
+              className="inline-flex items-center justify-center px-5 py-3 min-h-[44px] rounded-lg bg-yellow-400 hover:bg-yellow-300 text-indigo-900 text-base font-bold transition"
             >
               Join the Competition
             </Link>
           )}
           <Link
             to="/rules"
-            className="inline-flex items-center px-4 py-2 rounded-md bg-white/10 hover:bg-white/20 text-sm font-medium transition"
+            className="inline-flex items-center justify-center px-4 py-3 min-h-[44px] rounded-lg bg-white/10 hover:bg-white/20 text-base font-medium transition"
           >
             How It Works
           </Link>
@@ -86,7 +86,7 @@ const Home: React.FC = () => {
       </header>
 
       {/* Main Content Grid */}
-      <div className="grid gap-6 lg:grid-cols-2">
+      <div className="grid gap-4 sm:gap-6 lg:grid-cols-2">
         {/* Who Wins Market */}
         <div className="bg-white rounded-lg shadow-lg p-6">
           <h2 className="text-xl font-bold text-gray-900 mb-4">
@@ -200,7 +200,7 @@ const Home: React.FC = () => {
       </div>
 
       {/* Quick Links */}
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="grid gap-3 sm:gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <Link to="/side-bets" className="card hover:scale-[1.02] transition-transform">
           <h2 className="card-title">Side Bets</h2>
           <p className="card-body">Create or join fun side wagers outside the main market.</p>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -65,7 +65,7 @@ const Login: React.FC = () => {
                 type="email"
                 autoComplete="email"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                className="appearance-none rounded-none relative block w-full px-4 py-3 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 text-base"
                 placeholder="Email address"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
@@ -81,7 +81,7 @@ const Login: React.FC = () => {
                 type="password"
                 autoComplete="current-password"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                className="appearance-none rounded-none relative block w-full px-4 py-3 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 text-base"
                 placeholder="Password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
@@ -104,7 +104,7 @@ const Login: React.FC = () => {
             <button
               type="submit"
               disabled={isLoading}
-              className={`group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white ${
+              className={`group relative w-full flex justify-center items-center py-3 px-4 min-h-[44px] border border-transparent text-base font-semibold rounded-lg text-white transition ${
                 isLoading 
                   ? 'bg-indigo-400 cursor-not-allowed'
                   : 'bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500'

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -60,7 +60,7 @@ const Register: React.FC = () => {
                 name="name"
                 type="text"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                className="appearance-none rounded-none relative block w-full px-4 py-3 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 text-base"
                 placeholder="Full Name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
@@ -76,7 +76,7 @@ const Register: React.FC = () => {
                 type="email"
                 autoComplete="email"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                className="appearance-none rounded-none relative block w-full px-4 py-3 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 text-base"
                 placeholder="Email address"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
@@ -92,7 +92,7 @@ const Register: React.FC = () => {
                 type="password"
                 autoComplete="new-password"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                className="appearance-none rounded-none relative block w-full px-4 py-3 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 text-base"
                 placeholder="Password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
@@ -103,7 +103,7 @@ const Register: React.FC = () => {
           <div>
             <button
               type="submit"
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+              className="group relative w-full flex justify-center items-center py-3 px-4 min-h-[44px] border border-transparent text-base font-semibold rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition"
             >
               Sign up
             </button>

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -254,7 +254,7 @@ const ResetPassword: React.FC = () => {
                     navigate('/login', { replace: true });
                   }
                 }}
-                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                className="w-full flex justify-center items-center py-3 px-4 min-h-[44px] border border-transparent rounded-lg shadow-sm text-base font-semibold text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition"
                 data-testid="go-to-login-button"
               >
                 Go to Login
@@ -312,7 +312,7 @@ const ResetPassword: React.FC = () => {
                 type="submit"
                 disabled={loading}
                 data-testid="reset-password-button"
-                className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
+                className="group relative w-full flex justify-center items-center py-3 px-4 min-h-[44px] border border-transparent text-base font-semibold rounded-lg text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 transition"
               >
                 {loading ? <LoadingSpinner size="sm" data-testid="submit-spinner" /> : 'Reset Password'}
               </button>
@@ -359,11 +359,11 @@ const ResetPassword: React.FC = () => {
           {error && <ErrorMessage message={error} data-testid="error-message" />}
 
           <div>
-            <button
+              <button
               type="submit"
               disabled={loading}
               data-testid="send-reset-button"
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
+              className="group relative w-full flex justify-center items-center py-3 px-4 min-h-[44px] border border-transparent text-base font-semibold rounded-lg text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 transition"
             >
               {loading ? <LoadingSpinner size="sm" data-testid="submit-spinner" /> : 'Send Reset Instructions'}
             </button>

--- a/src/pages/StaticPages.tsx
+++ b/src/pages/StaticPages.tsx
@@ -49,31 +49,47 @@ const LeaderboardTable: React.FC = () => {
   }
 
   return (
-    <div className="overflow-x-auto">
-      <table className="min-w-full text-sm text-left" aria-label="Leaderboard table">
-        <thead className="border-b text-gray-700">
-          <tr>
-            <th scope="col" className="py-2 pr-4 font-medium">
-              Rank
-            </th>
-            <th scope="col" className="py-2 pr-4 font-medium">
-              Name
-            </th>
-            <th scope="col" className="py-2 pr-4 font-medium text-right">
-              Points
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {players.map((p: User, idx: number) => (
-            <tr key={p.id} className={idx % 2 ? 'bg-gray-50' : ''}>
-              <td className="py-2 pr-4">{idx + 1}</td>
-              <td className="py-2 pr-4">{p.name}</td>
-              <td className="py-2 pr-4 text-right font-semibold">{p.points}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className="space-y-2">
+      {players.map((p: User, idx: number) => (
+        <div
+          key={p.id}
+          className={`flex items-center justify-between p-4 rounded-lg ${
+            idx === 0
+              ? 'bg-yellow-50 border-2 border-yellow-300'
+              : idx === 1
+              ? 'bg-gray-100 border border-gray-300'
+              : idx === 2
+              ? 'bg-orange-50 border border-orange-200'
+              : 'bg-gray-50 border border-gray-200'
+          }`}
+        >
+          <div className="flex items-center gap-3">
+            <div
+              className={`flex items-center justify-center w-10 h-10 rounded-full font-bold text-sm ${
+                idx === 0
+                  ? 'bg-yellow-400 text-yellow-900'
+                  : idx === 1
+                  ? 'bg-gray-300 text-gray-700'
+                  : idx === 2
+                  ? 'bg-orange-300 text-orange-900'
+                  : 'bg-gray-200 text-gray-600'
+              }`}
+            >
+              {idx + 1}
+            </div>
+            <div>
+              <div className="font-semibold text-gray-900">{p.name}</div>
+              {p.role === 'admin' && (
+                <span className="text-xs text-gray-500">Admin</span>
+              )}
+            </div>
+          </div>
+          <div className="text-right">
+            <div className="font-bold text-indigo-600 text-lg">${p.points}</div>
+            <div className="text-xs text-gray-500">fake $</div>
+          </div>
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/pages/UserAdmin.tsx
+++ b/src/pages/UserAdmin.tsx
@@ -128,76 +128,50 @@ const UserAdmin: React.FC = () => {
         </div>
       )}
 
-      <div className="mt-8 flex flex-col">
-        <div className="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
-          <div className="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
-            <div className="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg">
-              <table className="min-w-full divide-y divide-gray-300">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th scope="col" className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
-                      Name
-                    </th>
-                    <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                      Email
-                    </th>
-                    <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                      Created At
-                    </th>
-                    <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                      Admin Status
-                    </th>
-                    <th scope="col" className="relative py-3.5 pl-3 pr-4 sm:pr-6">
-                      <span className="sr-only">Actions</span>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200 bg-white">
-                  {users.map((user) => (
-                    <tr key={user.id}>
-                      <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
-                        {user.name}
-                      </td>
-                      <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                        {user.email}
-                      </td>
-                      <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                        {new Date(user.created_at).toLocaleDateString()}
-                      </td>
-                      <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                        <span className={`inline-flex rounded-full px-2 text-xs font-semibold leading-5 ${
-                          user.is_admin 
-                            ? 'bg-green-100 text-green-800'
-                            : 'bg-gray-100 text-gray-800'
-                        }`}>
-                          {user.is_admin ? 'Admin' : 'User'}
-                        </span>
-                      </td>
-                      <td className="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                        <button
-                          onClick={() => toggleAdminStatus(user)}
-                          className="mr-2 text-indigo-600 hover:text-indigo-900"
-                        >
-                          {user.is_admin ? 'Remove Admin' : 'Make Admin'}
-                        </button>
-                        <button
-                          onClick={() => {
-                            if (window.confirm(`Are you sure you want to delete ${user.email}?`)) {
-                              deleteUser(user.id);
-                            }
-                          }}
-                          className="text-red-600 hover:text-red-900"
-                        >
-                          Delete
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+      <div className="mt-6 space-y-3">
+        {users.map((user) => (
+          <div
+            key={user.id}
+            className="bg-white p-4 rounded-lg shadow border border-gray-200"
+          >
+            <div className="mb-3">
+              <div className="flex items-start justify-between mb-2">
+                <div className="flex-1">
+                  <h4 className="text-base font-semibold text-gray-900">{user.name}</h4>
+                  <p className="text-sm text-gray-600 mt-1">{user.email}</p>
+                  <p className="text-xs text-gray-500 mt-1">
+                    Joined {new Date(user.created_at).toLocaleDateString()}
+                  </p>
+                </div>
+                <span className={`inline-flex rounded-full px-3 py-1 text-sm font-semibold ${
+                  user.is_admin 
+                    ? 'bg-green-100 text-green-800'
+                    : 'bg-gray-100 text-gray-800'
+                }`}>
+                  {user.is_admin ? 'Admin' : 'User'}
+                </span>
+              </div>
+            </div>
+            <div className="flex flex-col sm:flex-row gap-2">
+              <button
+                onClick={() => toggleAdminStatus(user)}
+                className="flex-1 px-4 py-2 min-h-[44px] rounded-lg border-2 border-indigo-600 text-base font-semibold text-indigo-600 hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-600 transition"
+              >
+                {user.is_admin ? 'Remove Admin' : 'Make Admin'}
+              </button>
+              <button
+                onClick={() => {
+                  if (window.confirm(`Are you sure you want to delete ${user.email}?`)) {
+                    deleteUser(user.id);
+                  }
+                }}
+                className="flex-1 px-4 py-2 min-h-[44px] rounded-lg bg-red-600 text-base font-semibold text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-600 transition"
+              >
+                Delete
+              </button>
             </div>
           </div>
-        </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

Transforms PolyDan from a desktop-oriented web app into a **mobile-first phone app** ready for deployment to poly-dan.com. All pages now work seamlessly on 390px screens with proper touch targets, no iOS zoom, and native app-like navigation.

**Schema**: Uses the existing CRA schema (users/champions/bets/transactions). Does NOT try to match the live Lovable app's database.

## What Changed

### 🎨 Mobile App Chrome
- **Bottom tab bar** on mobile with 4 tabs: Home, Bets (or Join if logged out), Leaderboard, More
- All tabs use **44×44px minimum tap targets** (Apple HIG compliant)
- **Safe area padding** with `env(safe-area-inset-bottom)` for notched devices
- Compact top bar on mobile: PolyDan logo + user balance
- "More" slide-up sheet for secondary navigation (Side Bets, Rules, FAQ, Profile, Admin)
- Desktop keeps the original top navigation experience

### 📱 iOS-Friendly Forms
- **All inputs/selects now use 16px font** on mobile (prevents iOS auto-zoom)
- Radio buttons enlarged from 16px to 20px with **full-row tap areas** (min 44px height)
- All primary buttons are **full-width on mobile** with min-height 44px
- Increased padding and spacing for comfortable thumb reach
- FormInput component standardized to text-base (16px) globally

### 🏠 Page Transformations
- **Home**: Single-column layout on mobile, hero buttons stack vertically, no overflow at 390px
- **Bets**: Large radio buttons, 16px inputs, prominent full-width submit button
- **Leaderboard**: Transformed from table to **stacked cards** with rank badges and point totals
- **Login/Register**: 16px inputs, 44px buttons, comfortable spacing
- **Admin**: Card-based champion management, 16px inputs, 44px action buttons, no tables on mobile
- **UserAdmin**: Stacked user cards instead of table, 44px touch targets
- **ResetPassword**: All buttons 44px, 16px inputs via FormInput

### 📦 PWA Enhancements
- Added `viewport-fit=cover` for proper notch handling
- Set `theme-color` to indigo-600 (#4F46E5)
- Apple PWA meta tags: `apple-mobile-web-app-capable`, `apple-mobile-web-app-title`
- Updated `manifest.json`: name "PolyDan", display "standalone", proper theme

### 🚀 Deploy Fix
- **Fixed GitHub workflow**: Now deploys on `main` branch instead of `master` (the actual default branch)
- Next push to main will automatically deploy to Heroku

## Testing

✅ TypeScript compilation: `tsc --noEmit` passes  
✅ All tests pass: `CI=true npm test --watchAll=false`  
✅ No changes to odds calculation logic (tests still green)

## Coverage

**Every page is now mobile-ready:**
- ✅ Home (single column, no overflow)
- ✅ Bets (16px inputs, 44px radios & buttons)
- ✅ Login / Register (16px inputs, 44px buttons)
- ✅ Leaderboard (stacked cards)
- ✅ Admin / Champion Management (stacked cards, 44px buttons)
- ✅ UserAdmin (stacked user cards)
- ✅ ResetPassword (44px buttons, 16px inputs)
- ✅ Rules, FAQ, Profile, Side Bets (mobile-friendly text)

## Deployment

Once merged to `main`, the updated GitHub Action will deploy automatically to Heroku. The next deploy will be the phone-first version.

---

**Before**: Desktop-first with hamburger menu, tiny radios, `sm:text-sm` inputs, data tables  
**After**: Phone-first with bottom tabs, 44px taps, 16px inputs, safe areas, stacked cards
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85256236-97b4-4a55-84c9-36f685dd6c12?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85256236-97b4-4a55-84c9-36f685dd6c12&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

