### PR TITLE
Bump fast-uri to 3.1.2 (Dependabot HIGH)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8936,9 +8936,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "homepage": "https://www.poly-dan.com",
+  "overrides": {
+    "fast-uri": "3.1.2"
+  },
   "engines": {
     "node": "18.x",
     "npm": "9.x"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Security Patch

Fixes two HIGH severity Dependabot alerts for the transitive dependency `fast-uri`:

- **CVE-2026-6321**: Path traversal via percent-encoded dot segments (fixed in 3.1.1)
- **CVE-2026-6322**: Host confusion via percent-encoded authority delimiters (fixed in 3.1.2)

## Changes

- Added npm `overrides` field in `package.json` to force `fast-uri` to version 3.1.2
- Updated `package-lock.json` via `npm install`
- Verified `node_modules/fast-uri` is now at 3.1.2 (was 3.0.6)
- All tests pass (3 suites, 13 tests)

## Verification

```
node_modules/fast-uri: 3.1.2 ✓
Tests: 13 passed, 13 total ✓
```

This is a security patch only. No application code, UI, or features have been changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45cf8298-6947-4919-abe4-faf01c8ac70d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45cf8298-6947-4919-abe4-faf01c8ac70d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

