### PR TITLE
Fix CI build: remove unused location variable in ResetPassword.tsx

### DIFF
--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -9,12 +9,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           
       - name: Install dependencies
         run: npm install

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import { toast } from 'react-hot-toast';
 import { FormInput } from '../components/common/FormInput';
@@ -75,7 +75,6 @@ const useResetToken = () => {
 
 const ResetPassword: React.FC = () => {
   const navigate = useNavigate();
-  const location = useLocation();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The GitHub Actions "Deploy to Heroku" workflow was failing on the **Build** step (`npm run build`).

### Root Cause

From the failed run logs ([#31844573972](https://github.com/matthewmcalear/PolyDan/actions/runs/31844573972)):

```
Treating warnings as errors because process.env.CI = true.
Most CI servers set it automatically.

Failed to compile.

[eslint] 
src/pages/ResetPassword.tsx
  Line 78:9:  'location' is assigned a value but never used  @typescript-eslint/no-unused-vars
```

When `CI=true` (set automatically by GitHub Actions), Create React App treats ESLint warnings as errors, causing the build to fail.

## Changes

1. **Fixed the ESLint error**: Removed unused `location` variable and import from `src/pages/ResetPassword.tsx`
2. **Updated GitHub Actions versions**: Bumped `actions/checkout@v3` → `@v4` and `actions/setup-node@v3` → `@v4` with Node 20.x (addresses Node.js 16 deprecation warnings)

## Testing

Verified locally that the build now succeeds with CI mode:
```bash
✓ CI=true npm run build
✓ CI=true npm test -- --watchAll=false
```

## Impact

- ✅ Build step will now pass in GitHub Actions
- ✅ Heroku deployment will proceed automatically on push to `main`
- ✅ No functional changes to the application
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8eacf6b9-f3d5-4fb2-ab83-878f3f8c4cff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8eacf6b9-f3d5-4fb2-ab83-878f3f8c4cff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

