### PR TITLE
Fix Heroku deploy step - install CLI on runner

### DIFF
--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -22,9 +22,12 @@ jobs:
       - name: Build
         run: npm run build
         
+      - name: Install Heroku CLI
+        run: curl https://cli-assets.heroku.com/install.sh | sh
+        
       - name: Deploy to Heroku
-        uses: akhileshns/heroku-deploy@v3.12.12
-        with:
-          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
-          heroku_app_name: "polydan"
-          heroku_email: ${{secrets.HEROKU_EMAIL}} 
+        env:
+          HEROKU_API_KEY: ${{secrets.HEROKU_API_KEY}}
+        run: |
+          heroku git:remote -a polydan
+          git push heroku HEAD:main 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The deploy step in `.github/workflows/heroku-deploy.yml` was failing with:
```
/bin/sh: 1: heroku: not found
##[error]Error: Command failed: heroku create polydan
```

The `akhileshns/heroku-deploy@v3.12.12` action expects the Heroku CLI to be available on the runner, but it is not installed by default on `ubuntu-latest` runners.

**Failed run:** https://github.com/matthewmcalear/PolyDan/actions/runs/31844987724

## Solution

- Install Heroku CLI using the official install script before deploying
- Replace the third-party action with native Heroku CLI commands (`heroku git:remote` + `git push`)
- Continue using existing `HEROKU_API_KEY` secret (no new secrets required)

## Changes

- Added "Install Heroku CLI" step using `curl https://cli-assets.heroku.com/install.sh | sh`
- Changed deploy step to use Heroku CLI directly: `heroku git:remote -a polydan` and `git push heroku HEAD:main`
- Removed dependency on unmaintained `akhileshns/heroku-deploy` action

This approach is more transparent and uses officially supported Heroku tooling.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-822d2124-19d9-4cab-8a0c-1f0abe1a7e23?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-822d2124-19d9-4cab-8a0c-1f0abe1a7e23&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

