### PR TITLE
Fix Heroku app name to polydan-1f195a22e2e0

### DIFF
--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -29,5 +29,5 @@ jobs:
         env:
           HEROKU_API_KEY: ${{secrets.HEROKU_API_KEY}}
         run: |
-          heroku git:remote -a polydan
+          heroku git:remote -a polydan-1f195a22e2e0
           git push heroku HEAD:main 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After fixing the Heroku CLI installation (PR #9), the deploy now fails with:
```
Error: Couldn't find that app.
Error ID: not_found
```

The workflow was using app name `polydan`, but that app does not exist on Heroku.

**Failed run:** https://github.com/matthewmcalear/PolyDan/actions/runs/31845282031

## Solution

Updated the app name to `polydan-1f195a22e2e0` - the actual Heroku app name found in git history (commit `351c3d1`) where it was used in production password reset URLs.

## Changes

- Changed `heroku git:remote -a polydan` to `heroku git:remote -a polydan-1f195a22e2e0`

This should allow the deploy to proceed if the app still exists and the API key is valid.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-822d2124-19d9-4cab-8a0c-1f0abe1a7e23?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-822d2124-19d9-4cab-8a0c-1f0abe1a7e23&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

