### PR TITLE
Fix Heroku deployment authentication in GitHub Action

### DIFF
--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -29,5 +29,5 @@ jobs:
         env:
           HEROKU_API_KEY: ${{secrets.HEROKU_API_KEY}}
         run: |
-          heroku git:remote -a polydan
+          git remote add heroku "https://heroku:${HEROKU_API_KEY}@git.heroku.com/polydan.git" || git remote set-url heroku "https://heroku:${HEROKU_API_KEY}@git.heroku.com/polydan.git"
           git push heroku HEAD:main 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
The "Deploy to Heroku" step was failing in ~1 second because `heroku git:remote -a polydan` sets up a remote without credentials. In CI environments, this fails immediately since there's no interactive login available.

## Solution
Updated the workflow to embed the `HEROKU_API_KEY` directly in the git remote URL:
```bash
git remote add heroku "https://heroku:${HEROKU_API_KEY}@git.heroku.com/polydan.git" || git remote set-url heroku "https://heroku:${HEROKU_API_KEY}@git.heroku.com/polydan.git"
```

This allows git to authenticate using the API key without requiring the Heroku CLI's interactive login.

## Testing
- Build step already succeeds in GitHub Actions
- This fix will allow the deployment to actually reach Heroku and trigger a build
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e4ee157-b838-455c-b598-5a683b98d65f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e4ee157-b838-455c-b598-5a683b98d65f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

